### PR TITLE
Specify the address family as IPv4

### DIFF
--- a/NLog.Target.Gelf/NLog.Targets.Gelf.cs
+++ b/NLog.Target.Gelf/NLog.Targets.Gelf.cs
@@ -17,7 +17,7 @@ namespace NLog.Targets.Gelf
     {
         #region Private Members
 
-        private static readonly Socket SocketClient = new Socket(SocketType.Dgram, ProtocolType.Udp);
+        private static readonly Socket SocketClient = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
         private static readonly ConcurrentDictionary<string, IPEndPoint> EndPoints = new ConcurrentDictionary<string, IPEndPoint>();
 
         private const int ShortMessageLength = 250;


### PR DESCRIPTION
This was necessary to make it work from an Azure Web Site. This is a light-weight version of the pull request @FireNGlory created. I basically had the same issue. I would also support merging that pull request instead, but I don't have a clear idea about the rest of that pull request.
